### PR TITLE
Fallback to author.login if committer.login isn't available

### DIFF
--- a/src/functions/get-committer-login.ts
+++ b/src/functions/get-committer-login.ts
@@ -19,7 +19,8 @@ export async function getRecentCommitLogin(sha: string): Promise<string> {
       per_page: 1,
       page: 1
     })
-    lastCommitter = commitResponse.data.committer!.login
+    const commitData = commitResponse.data;
+    lastCommitter = commitData.committer?.login || commitData.author!.login;
     assert.ok(lastCommitter, 'Committer cannot be empty.')
   } catch (err) {
     if (err instanceof Error) {


### PR DESCRIPTION
There are cases where the committer is empty, but the author is not. Use that when there's no committer info.